### PR TITLE
Fix shadow types: inner and none

### DIFF
--- a/demos/browser/index.html
+++ b/demos/browser/index.html
@@ -743,6 +743,14 @@
 									<li>Source: URL variables</li>
 								</ul>
 							</div>
+							<div class="col">
+								<h6 class="text-primary">Slide 5: Image Shadows</h6>
+								<ul class="mb-0">
+									<li>Type: Outer</li>
+									<li>Type: None</li>
+									<li>Type: Inner</li>
+								</ul>
+							</div>
 						</div>
 					</div>
 					<div class="card-footer text-center">

--- a/demos/modules/demo_image.mjs
+++ b/demos/modules/demo_image.mjs
@@ -27,6 +27,7 @@ export function genSlides_Image(pptx) {
 	genSlide02(pptx);
 	genSlide03(pptx);
 	genSlide04(pptx);
+	genSlide05(pptx);
 }
 
 /**
@@ -278,4 +279,30 @@ function genSlide04(pptx) {
 		}
 	);
 	slide.addImage({ path: IMAGE_PATHS.sydneyBridge.path, x: 0.5, y: 5.16, h: 1.8, w: 12.33 });
+}
+
+/**
+ * SLIDE 5: Image Shadow
+ * @param {PptxGenJS} pptx
+ */
+ function genSlide05(pptx) {
+	let slide = pptx.addSlide({ sectionTitle: "Images" });
+
+	slide.addTable([[{ text: "Image Examples: Shadows", options: BASE_TEXT_OPTS_L }, BASE_TEXT_OPTS_R]], BASE_TABLE_OPTS);
+	slide.addNotes("API Docs: https://gitbrent.github.io/PptxGenJS/docs/api-images.html");
+	slide.slideNumber = { x: "50%", y: "95%", w: 1, h: 1, color: COLOR_BLUE };
+
+	// EXAMPLES
+
+	// OUTER SHADOW
+	slide.addText("Shadow: `type:outer`, `opacity:0.5`, `blur:20`, `color:000000`, `offset:20`, `angle:270`", { x: 0.5, y: 0.6, w: 6.0, h: 0.3, color: COLOR_BLUE });
+	slide.addImage({ path: IMAGE_PATHS.tokyoSubway.path, x: 0.78, y: 2.46, w: 3.3, h: 2, shadow: {type: 'outer', opacity: 0.5, blur: 20, color: '000000', offset: 20, angle: 270} });
+
+	// NO SHADOW
+	slide.addText("Shadow: `type:none`", { x: 5, y: 1.2, w: 6.0, h: 0.3, color: COLOR_BLUE });
+	slide.addImage({ path: IMAGE_PATHS.tokyoSubway.path, x: 4.52, y: 2.46, w: 3.3, h: 2, shadow: {type: 'none'} });
+
+	// INNER SHADOW
+	slide.addText("Shadow: `type:inner`, `opacity:1`, `blur:20`, `color:000000`, `offset:20`, `angle:270`", { x: 8, y: 0.6, w: 6.0, h: 0.3, color: COLOR_BLUE });
+	slide.addImage({ path: IMAGE_PATHS.tokyoSubway.path, x: 8.42, y: 2.46, w: 3.3, h: 2, shadow: {type: 'inner', opacity: 1, blur: 20, color: '000000', offset: 20, angle: 270} });
 }

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -524,7 +524,7 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				}
 
 				// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
-				if (slideItemObj.options.shadow) {
+				if (slideItemObj.options.shadow && slideItemObj.options.shadow.type !== 'none') {
 					slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
 					slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
 					slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
@@ -533,12 +533,13 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
 
 					strSlideXml += '<a:effectLst>'
-					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
-					strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw'
+					strSlideXml += slideItemObj.options.shadow.type === 'outer' ? ' sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0"' : ''
+					strSlideXml += ' blurRad="' + slideItemObj.options.shadow.blur + '"'
 					strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
 					strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
 					strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
-					strSlideXml += '</a:outerShdw>'
+					strSlideXml += '</a:' + slideItemObj.options.shadow.type + 'Shdw>'
 					strSlideXml += '</a:effectLst>'
 				}
 
@@ -628,10 +629,9 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 				strSlideXml += '  <a:ext cx="' + width + '" cy="' + height + '"/>'
 				strSlideXml += ' </a:xfrm>'
 				strSlideXml += ' <a:prstGeom prst="' + (rounding ? 'ellipse' : 'rect') + '"><a:avLst/></a:prstGeom>'
-				strSlideXml += solidFillXmlString
-				// UGH: COPY-PASTA FROM SHAPE
+
 				// EFFECTS > SHADOW: REF: @see http://officeopenxml.com/drwSp-effects.php
-				if (slideItemObj.options.shadow) {
+				if (slideItemObj.options.shadow && slideItemObj.options.shadow.type !== 'none') {
 					slideItemObj.options.shadow.type = slideItemObj.options.shadow.type || 'outer'
 					slideItemObj.options.shadow.blur = valToPts(slideItemObj.options.shadow.blur || 8)
 					slideItemObj.options.shadow.offset = valToPts(slideItemObj.options.shadow.offset || 4)
@@ -640,12 +640,13 @@ function slideObjectToXml(slide: PresSlide | SlideLayout): string {
 					slideItemObj.options.shadow.color = slideItemObj.options.shadow.color || DEF_TEXT_SHADOW.color
 
 					strSlideXml += '<a:effectLst>'
-					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw sx="100000" sy="100000" kx="0" ky="0" '
-					strSlideXml += ' algn="bl" rotWithShape="0" blurRad="' + slideItemObj.options.shadow.blur + '" '
+					strSlideXml += '<a:' + slideItemObj.options.shadow.type + 'Shdw'
+					strSlideXml += slideItemObj.options.shadow.type === 'outer' ? ' sx="100000" sy="100000" kx="0" ky="0" algn="bl" rotWithShape="0"' : ''
+					strSlideXml += ' blurRad="' + slideItemObj.options.shadow.blur + '"'
 					strSlideXml += ' dist="' + slideItemObj.options.shadow.offset + '" dir="' + slideItemObj.options.shadow.angle + '">'
 					strSlideXml += '<a:srgbClr val="' + slideItemObj.options.shadow.color + '">'
 					strSlideXml += '<a:alpha val="' + slideItemObj.options.shadow.opacity + '"/></a:srgbClr>'
-					strSlideXml += '</a:outerShdw>'
+					strSlideXml += '</a:' + slideItemObj.options.shadow.type + 'Shdw>'
 					strSlideXml += '</a:effectLst>'
 				}
 				strSlideXml += '</p:spPr>'


### PR DESCRIPTION
This PR fixes a previously undetected bug for shadow types `none` and `inner` which images and shapes. 
Since Pitch only uses the type `outer` for images, the bug did not break export.

Code Snippet for the Sandbox

```js
let pptx = new PptxGenJS();
let slide = pptx.addSlide();

slide.addImage({
  x: 1,
  y: 2,
  path: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMTIyMnwwfDF8c2VhcmNofDJ8fGxhbmRzY2FwZXxlbnwwfHx8fDE2NTg5MzE0MDM&ixlib=rb-1.2.1&q=80&w=1080",
  shadow: {
    type: "none",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  }
});

slide.addImage({
  x: 3,
  y: 2,
  path: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMTIyMnwwfDF8c2VhcmNofDJ8fGxhbmRzY2FwZXxlbnwwfHx8fDE2NTg5MzE0MDM&ixlib=rb-1.2.1&q=80&w=1080",
  shadow: {
    type: "inner",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  }
});

slide.addImage({
  x: 5,
  y: 2,
  path: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMTIyMnwwfDF8c2VhcmNofDJ8fGxhbmRzY2FwZXxlbnwwfHx8fDE2NTg5MzE0MDM&ixlib=rb-1.2.1&q=80&w=1080",
  shadow: {
    type: "outer",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  }
});

// When type is not provided, defaults to `outer`
slide.addImage({
  x: 7,
  y: 2,
  path: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=MnwyMTIyMnwwfDF8c2VhcmNofDJ8fGxhbmRzY2FwZXxlbnwwfHx8fDE2NTg5MzE0MDM&ixlib=rb-1.2.1&q=80&w=1080",
  shadow: {
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  }
});

slide.addShape(pptx.ShapeType.rect, { fill: { color: "FF0000" }, x: 1, y: 0.5, shadow: {
    type: "none",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  } });

  slide.addShape(pptx.ShapeType.rect, { fill: { color: "FF0000" }, x: 3, y: 0.5, shadow: {
    type: "inner",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  } });

  slide.addShape(pptx.ShapeType.rect, { fill: { color: "FF0000" }, x: 5, y: 0.5, shadow: {
    type: "outer",
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  } });

// When type is not provided, defaults to `outer`
  slide.addShape(pptx.ShapeType.rect, { fill: { color: "FF0000" }, x: 7, y: 0.5, shadow: {
    angle: 90,
    blur: 10,
    color: "000000",
    offset: 4,
    opacity: 1
  } });

pptx.writeFile({ fileName: "PptxGenJS-Shadows.pptx" });
```