### PR TITLE
Allow external fonts to PPTX

### DIFF
--- a/src/core-interfaces.ts
+++ b/src/core-interfaces.ts
@@ -1830,6 +1830,7 @@ export interface AddSlideProps {
 export interface PresentationProps {
 	author: string
 	company: string
+	fonts: PresFont[]
 	layout: string
 	masterSlide: PresSlide
 	/**
@@ -1851,4 +1852,27 @@ export interface IPresentationProps extends PresentationProps {
 	sections: SectionProps[]
 	slideLayouts: SlideLayout[]
 	slides: PresSlide[]
+}
+
+export interface FontProps {
+	name: string
+	styles: FontStyleProps[]
+}
+
+export interface FontStyleProps {
+	name: 'regular' | 'bold' | 'italic' | 'boldItalic'
+	data?: string | ArrayBuffer
+	path?: string
+}
+
+export interface PresFontStyle extends FontStyleProps {
+	rel: {
+		id: string
+		target: string
+	}
+}
+
+export interface PresFont {
+	name: string
+	styles: PresFontStyle[]
 }

--- a/src/gen-fonts.ts
+++ b/src/gen-fonts.ts
@@ -1,0 +1,40 @@
+import { FontProps, FontStyleProps, PresFont, PresFontStyle } from './core-interfaces'
+
+export const encodePresFontRels = (fonts: PresFont[]): Promise<string>[] =>
+	fonts
+		.map(f => f.styles)
+		.flat()
+		.filter(v => !v.data && v.path)
+		.map(loadFontStyle)
+
+const loadFontStyle = (style: PresFontStyle): Promise<string> =>
+	new Promise((resolve, reject) => {
+		const xhr = new XMLHttpRequest()
+
+		xhr.onload = () => {
+			const reader = new FileReader()
+			reader.onloadend = () => {
+				style.data = reader.result
+				resolve('done')
+			}
+			reader.readAsDataURL(xhr.response)
+		}
+
+		xhr.onerror = ex => {
+			reject(`ERROR! Unable to load font (xhr.onerror): ${style.path}`)
+		}
+
+		xhr.open('GET', style.path)
+		xhr.responseType = 'blob'
+		xhr.send()
+	})
+
+const validStyles = ['regular', 'bold', 'italic', 'boldItalic']
+
+const isValidStyle = (style: FontStyleProps) => typeof style === 'object' && validStyles.includes(style.name) && (style.path || style.data)
+
+const isValidStyles = (styles: FontStyleProps[]) => Array.isArray(styles) && styles.every(isValidStyle)
+
+const isValidFont = (font: FontProps) => typeof font === 'object' && font.name !== '' && isValidStyles(font.styles)
+
+export const isValidFonts = (fonts: FontProps[]) => Array.isArray(fonts) && fonts.every(isValidFont)

--- a/src/gen-xml.ts
+++ b/src/gen-xml.ts
@@ -24,6 +24,7 @@ import {
 	ISlideRelChart,
 	ISlideRelMedia,
 	ObjectOptions,
+	PresFont,
 	PresSlide,
 	ShadowProps,
 	SlideLayout,
@@ -1484,6 +1485,7 @@ export function makeXmlContTypes(slides: PresSlide[], slideLayouts: SlideLayout[
 	strXml += '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
 	strXml += '<Default Extension="jpeg" ContentType="image/jpeg"/>'
 	strXml += '<Default Extension="jpg" ContentType="image/jpg"/>'
+	strXml += '<Default Extension="fntdata" ContentType="application/x-fontdata"/>'
 
 	// STEP 1: Add standard/any media types used in Presentation
 	strXml += '<Default Extension="png" ContentType="image/png"/>'
@@ -1639,7 +1641,7 @@ export function makeXmlCore(title: string, subject: string, author: string, revi
  * @param {PresSlide[]} slides - Presenation Slides
  * @returns XML
  */
-export function makeXmlPresentationRels(slides: Array<PresSlide>): string {
+export function makeXmlPresentationRels(slides: Array<PresSlide>, fonts: Array<PresFont>): string {
 	let intRelNum = 1
 	let strXml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + CRLF
 	strXml += '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
@@ -1648,24 +1650,33 @@ export function makeXmlPresentationRels(slides: Array<PresSlide>): string {
 		strXml +=
 			'<Relationship Id="rId' + ++intRelNum + '" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide' + idx + '.xml"/>'
 	}
+
 	intRelNum++
 	strXml +=
 		'<Relationship Id="rId' +
-		intRelNum +
+		intRelNum++ +
 		'" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" Target="notesMasters/notesMaster1.xml"/>' +
 		'<Relationship Id="rId' +
-		(intRelNum + 1) +
+		intRelNum++ +
 		'" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/presProps" Target="presProps.xml"/>' +
 		'<Relationship Id="rId' +
-		(intRelNum + 2) +
+		intRelNum++ +
 		'" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps" Target="viewProps.xml"/>' +
 		'<Relationship Id="rId' +
-		(intRelNum + 3) +
+		intRelNum++ +
 		'" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>' +
 		'<Relationship Id="rId' +
-		(intRelNum + 4) +
-		'" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles" Target="tableStyles.xml"/>' +
-		'</Relationships>'
+		intRelNum++ +
+		'" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles" Target="tableStyles.xml"/>'
+
+	fonts.forEach(font => {
+		font.styles.forEach(style => {
+			style.rel.id = `rId${intRelNum}` // populate rel id
+			strXml += `<Relationship Id="rId${intRelNum++}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/font" Target="${style.rel.target}"/>`
+		})
+	})
+
+	strXml += '</Relationships>'
 
 	return strXml
 }
@@ -1948,6 +1959,22 @@ export function makeXmlPresentation(pres: IPresentationProps): string {
 	// STEP 4: Add sizes
 	strXml += `<p:sldSz cx="${pres.presLayout.width}" cy="${pres.presLayout.height}"/>`
 	strXml += `<p:notesSz cx="${pres.presLayout.height}" cy="${pres.presLayout.width}"/>`
+
+	// STEP: Add embedded fonts
+	if (pres.fonts.length > 0) {
+		strXml += '<p:embeddedFontLst>'
+
+		pres.fonts.forEach(font => {
+			strXml += '<p:embeddedFont>'
+			strXml += `<p:font typeface="${font.name}"/>`
+			font.styles.forEach(style => {
+				strXml += `<p:${style.name} r:id="${style.rel.id}"/>`
+			})
+			strXml += '</p:embeddedFont>'
+		})
+
+		strXml += '</p:embeddedFontLst>'
+	}
 
 	// STEP 5: Add text styles
 	strXml += '<p:defaultTextStyle>'


### PR DESCRIPTION
This PR adds an `addFonts` method which enables external fonts to be added to the PPTX.

#### How to test
1. Pull changes
2. Bundle lib - `npm run ship`
3. Run demos - `cd demos; node ./browser_server.mjs`
4. Try out API

Example:
```tsx
pptx.addFonts([
  { 
    name: "Roboto",
    styles: [
      { name: "regular", path: "http://localhost:8080/roboto-regular.fntdata" },
      { name: "bold", path: "http://localhost:8080/roboto-bold.fntdata" }
    ]
  }
])
```

In order to pass a valid path to `.fntdata` files you can serve them locally. Note: consider CORS when serving.

#### Follow up
- Build JS assets to `dist` 
- Add new tag
- Include in pptx-exporter